### PR TITLE
[fix]土地のOwnerを変更した際に旧Ownerの所有物件リストが新オーナーのものに書き変わる不具合を修正

### DIFF
--- a/src/main/kotlin/red/man10/realestate/region/Region.kt
+++ b/src/main/kotlin/red/man10/realestate/region/Region.kt
@@ -140,7 +140,7 @@ class Region(private val pl:Plugin) {
             val old = Bukkit.getPlayer(data.ownerUUID!!)
 
             if (old !=null){
-                val list = user.ownerList[p]!!
+                val list = user.ownerList[old]!!
                 list.remove(id)
                 user.ownerList[old] = list
             }


### PR DESCRIPTION
ソースコードを見た限りでは、listには新しいオーナーのリストが格納されていて
その中から移譲する（実際には存在してない）idを削除して、
元のオーナーのリストに書き込んでいるため、
元のオーナーのリストが新しいオーナーのリストに書き変わってしまう不具合。
ただし、DBへ書き込みをしていないのでリログすると直る。

satimilkさんによる追検証：
```
junpei　からID:82の土地のオーナーを貰った所
junpei　は、　satimilk　が所有する土地全て+自分の土地を
mre画面で確認できるようになっていた。
そこで、　junpei　にID:224（　satimilk　が所有する土地）
をonsale状態にしてもらった所
私の所有する土地はProtectedのままで、変動はなかった。
また、住民の追加もテストしてもらったが
t_takahiro　に「住民になりますか？」などのテキストが届かず
住民にはなれなかった。
よって、このバグで実行可能なことは
住民の確認程度であることが確認できた。
さらに、このバグはリログすると直ることも確認できた。
```